### PR TITLE
fixed buggy split behaviour

### DIFF
--- a/lua/styler/init.lua
+++ b/lua/styler/init.lua
@@ -80,7 +80,7 @@ function M.setup(opts)
     end,
   })
 
-  vim.api.nvim_create_autocmd({ "FileType", "BufWinEnter" ,"WinEnter"}, {
+  vim.api.nvim_create_autocmd({ "FileType", "BufWinEnter" ,"WinNew"}, {
     group = group,
     callback = function(event)
       M.update({ buf = event.buf })

--- a/lua/styler/init.lua
+++ b/lua/styler/init.lua
@@ -80,7 +80,7 @@ function M.setup(opts)
     end,
   })
 
-  vim.api.nvim_create_autocmd({ "FileType", "BufWinEnter" }, {
+  vim.api.nvim_create_autocmd({ "FileType", "BufWinEnter" ,"WinEnter"}, {
     group = group,
     callback = function(event)
       M.update({ buf = event.buf })


### PR DESCRIPTION
When in a styled Window and creating new splits with '<C-w>v' or '<C-w>s' the split-up window would not inherit the style. Can be easily fixed by extending the aucmd-events. Also fixes #4