### PR TITLE
fix: unset eventignore with empty string instead of nil

### DIFF
--- a/lua/styler/theme.lua
+++ b/lua/styler/theme.lua
@@ -79,7 +79,7 @@ function M:after()
   end
 
   -- enable autocmds
-  vim.go.eventignore = nil
+  vim.go.eventignore = ""
 
   -- schedule theme reload
   vim.schedule(function()


### PR DESCRIPTION
Otherwise, the error like below occurs in recent neovim.
I found this on nightly.

> Error executing vim.schedule lua callback: .../.local/share/nvim/lazy/styler.nvim/lua/styler/theme.lua:82: Cannot unset global option value

## :version

```
NVIM v0.10.0-dev-a935c75
Build type: RelWithDebInfo
LuaJIT 2.1.1699198486
Run ":verbose version" for more info
```