### PR TITLE
fix(colorscheme): don't set theme on win with theme already set

### DIFF
--- a/lua/styler/init.lua
+++ b/lua/styler/init.lua
@@ -13,6 +13,10 @@ M.bufs = {}
 function M.set_theme(win, theme)
   win = win == 0 and vim.api.nvim_get_current_win() or win
 
+  if vim.w[win].theme and vim.w[win].theme.colorscheme == theme.colorscheme then
+    return
+  end
+
   vim.w[win].theme = theme
   local ns = require("styler.theme").load(theme)
   vim.api.nvim_win_set_hl_ns(win, ns)


### PR DESCRIPTION
if a plugin - e.g. levouh/tint.nvim - changes a windows hl_ns on WinLeave, styler overwrites these changes.

WinLeave - tint sets new hl_ns
WinNew - styler sets hl_ns on all windows containing the buffer of new window overwriting the changes on WinLeave